### PR TITLE
[SE-51181] Updating previous fix for iterator getting in an infinite …

### DIFF
--- a/core/dom/iterator.js
+++ b/core/dom/iterator.js
@@ -167,10 +167,12 @@
 					var nodeName = currentNode.getName();
 
 					// Non-editable block was found - return it and move to processing
-					// its nested editables if they exist.					
-					// [SE-50798] Patched the iterator to handle all `contenteditable=false` elements. 
+					// its nested editables if they exist.
+					// [SE-50798] Patched the iterator to handle all `contenteditable=false` elements.
 					//            Ignoring inline non-editable elements can potentially lead to an infinite loop
-					if ( /* CKEDITOR.dtd.$block[ nodeName ] && */ currentNode.getAttribute( 'contenteditable' ) == 'false' ) {
+					if ( ( CKEDITOR.dtd.$block[ nodeName ] || hasNestedElements( currentNode ) ) &&
+						 currentNode.getAttribute( 'contenteditable' ) == 'false' )
+					{
 						block = currentNode;
 
 						// Setup iterator for first of nested editables.
@@ -391,6 +393,28 @@
 			return next;
 		}
 	};
+
+	/**
+	 * @param {CKEDITOR.dom.element} element
+	 * @returns {boolean} whether an element has nested non-text elements
+	 */
+	function hasNestedElements(element) {
+		if (!(element instanceof CKEDITOR.dom.element)) {
+			return false;
+		}
+		var children = element.getChildren();
+		if (!children) {
+			return false;
+		}
+		var count = children.count();
+		for (var i = 0; i < count; i++) {
+			var child = children.getItem(i);
+			if (child instanceof CKEDITOR.dom.element) {
+				return true;
+			}
+		}
+		return false;
+	}
 
 	// @context CKEDITOR.dom.iterator
 	// @returns Collapsed range which will be reused when during furter processing.

--- a/plugins/justify/plugin.js
+++ b/plugins/justify/plugin.js
@@ -63,7 +63,7 @@
 		}
 
 		this.allowedContent = {
-			'caption div span h1 h2 h3 h4 h5 h6 p pre td th li': {
+			'caption div h1 h2 h3 h4 h5 h6 p pre td th li': {
 				// Do not add elements, but only text-align style if element is validated by other rule.
 				propertiesOnly: true,
 				styles: this.cssClassName ? null : 'text-align',


### PR DESCRIPTION
Updating previous fix for iterator getting in an infinite loop with placeholders.
Updated the logic so that the fix only targets palceholders with nested elements, and not formulas with only inner text. 
The last update had an unintentional side effect with makes justify/other alignment buttons not work on paragraphs with a formula 
That means alignment is still not working with placeholders, which is annoying, but still better than the old behavior which was for ckeditor to mangle the placeholders' inner html